### PR TITLE
should use https protocol on iOS9

### DIFF
--- a/Classes/Media.h
+++ b/Classes/Media.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#define MEDIA_URL_BASE @"http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/"
+#define MEDIA_URL_BASE @"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/"
 #define MEDIA_URL_FILE @"d.json"
 
 /**


### PR DESCRIPTION
Hi @ianbarber ,

Trying to solve the MediaTableViewController empty problem (iOS9+ only), 
on iOS 9+ devices, apple requires connections to support TLS 1.2+
for more informations please reference https://developer.apple.com/library/prerelease/ios/technotes/App-Transport-Security-Technote/

please let me know if any fix/style/documentation or further information is required. :smile: 