### PR TITLE
Add missing reference to cast session

### DIFF
--- a/CastVideos-swift/Classes/MediaTableViewController.swift
+++ b/CastVideos-swift/Classes/MediaTableViewController.swift
@@ -257,6 +257,7 @@ class MediaTableViewController: UITableViewController, GCKSessionManagerListener
       } else {
         let options = GCKMediaQueueLoadOptions()
         options.repeatMode = remoteMediaClient.mediaStatus?.queueRepeatMode ?? .off
+        castSession = sessionManager.currentSession as? GCKCastSession
         let request = castSession.remoteMediaClient?.queueLoad([item()], with: options)
         request?.delegate = self
       }


### PR DESCRIPTION
There was a crash when playing a video from the MediaTableViewController
using the action sheet Play Now action